### PR TITLE
Update 2020-04-19-data-file.md

### DIFF
--- a/_docs/30-output/2020-04-19-data-file.md
+++ b/_docs/30-output/2020-04-19-data-file.md
@@ -20,7 +20,7 @@ Eigenvalue $$ \varepsilon_{i,\mathbf{k}} $$ of each  $$ \phi_{i\mathbf{k}}(\math
 
 
 - `pwscf.pop0.dat`<br>
-Occupation at each $$ \phi_{i\mathbf{k}}(\mathbf{G},t=0)  $$, i.e. $$  \sum_\gamma q_{\gamma \mathbf{k}} | \left \langle \psi_{\gamma \mathbf{k} }( \mathbf{G},t) |   \psi_{\gamma \mathbf{k} }( \mathbf{G},t=0)  \right \rangle |^2 $$
+Occupation at each $$ \phi_{i\mathbf{k}}(\mathbf{G},t=0)  $$, i.e. $$  \sum_\gamma q_{\gamma \mathbf{k}} | \left \langle \psi_{\gamma \mathbf{k} }( \mathbf{G},t) |   \psi_{i \mathbf{k} }( \mathbf{G},t=0)  \right \rangle |^2 $$
 
 
 


### PR DESCRIPTION
Fixed a mistake for pwscf.pop0.dat. Subscript of ket should be i, rather $\gamma$.